### PR TITLE
Add features resolve modules directories

### DIFF
--- a/lib/js-hyperclick.js
+++ b/lib/js-hyperclick.js
@@ -24,6 +24,13 @@ module.exports = {
             // Default comes from Node's `require.extensions`
             default: [ '.js', '.json', '.node' ],
             items: { type: 'string' },
+        },
+        resolveModulesDirectories: {
+          description: "Comma separated list of directories to resolve file for webpack users",
+          type: 'array',
+          // Default comes from nothing
+          default: [ '' ],
+          items: { type: 'string' },
         }
     },
     activate(state) {

--- a/lib/suggestions.js
+++ b/lib/suggestions.js
@@ -4,11 +4,13 @@
 import url from 'url'
 import shell from 'shell'
 import path from 'path'
+import fs from 'fs'
 import { sync as resolve } from 'resolve'
 import { Range } from 'atom'
 
 function resolveModule(textEditor, module) {
     const basedir = path.dirname(textEditor.getPath())
+    const resolveModulesDirectories = atom.config.get('js-hyperclick.resolveModulesDirectories')
     const options = {
         basedir,
         extensions: atom.config.get('js-hyperclick.extensions')
@@ -31,6 +33,31 @@ function resolveModule(textEditor, module) {
         }
 
         return path.join(basedir, module)
+    }
+
+    // Allow to resolve module directories to the current directory and searched for modules
+    if (resolveModulesDirectories.length > 0) {
+      if (path.extname(module) == '') {
+          module += '.js'
+      }
+
+      var filename;
+
+      atom.project.getPaths().forEach(projectPath => {
+          if (textEditor.getPath().indexOf(projectPath) !== -1) {
+              resolveModulesDirectories.forEach(moduleDirectory => {
+                  let resolvePath = path.join(path.join(projectPath, moduleDirectory), module);
+                  try {
+                      fs.accessSync(resolvePath, fs.F_OK);
+                      filename = resolvePath;
+                  } catch (e) {
+                    /* do nothing */
+                  }
+              });
+          }
+      });
+
+      return filename
     }
 }
 


### PR DESCRIPTION
Add features for webpack users to resolve modules directories.

see this below webpack config page.
http://webpack.github.io/docs/configuration.html#resolve-modulesdirectories

hello~ it's first time to pull request for my whole life.
I might be something wrong with step pull request.
I'll appreciate that if you kindly comment about this.
thank you and have a great day.