### PR TITLE
fixed "missing providerName "

### DIFF
--- a/lib/js-hyperclick.js
+++ b/lib/js-hyperclick.js
@@ -8,6 +8,7 @@ function makeProvider(subscriptions) {
 
 
     return {
+        providerName:'js-hyperclick',
         getSuggestionForWord(textEditor, text, range) {
             if (isJavascript(textEditor)) {
                 return suggestions(textEditor, text, range, cache)


### PR DESCRIPTION
Hi,
After Installing hyperclyck 0.0.35 and js-hyperclick 1.4 (I didn't try other versions)
I've got error "missing providerName" similar to this https://github.com/atom/atom/issues/9673

fix is to add providerName to returned provider  