### PR TITLE
Use modulesDirectories from webpack config for module resolving.

### DIFF
--- a/lib/js-hyperclick.js
+++ b/lib/js-hyperclick.js
@@ -25,6 +25,12 @@ module.exports = {
             // Default comes from Node's `require.extensions`
             default: [ '.js', '.json', '.node' ],
             items: { type: 'string' },
+        },
+        webpackConfigs: {
+            description: "Comma separated list of paths to webpack config to get modulesDirectories from",
+            type: 'array',
+            default: [ 'webpack.config.js' ],
+            items: { type: 'string' },
         }
     },
     activate(state) {

--- a/lib/suggestions.js
+++ b/lib/suggestions.js
@@ -9,8 +9,23 @@ import { Range } from 'atom'
 
 function resolveModule(textEditor, module) {
     const basedir = path.dirname(textEditor.getPath())
+
+    const moduleDirectory = [ 'node_modules' ]
+    const webpackConfigs = atom.config.get('js-hyperclick.webpackConfigs')
+    webpackConfigs.forEach(configFileName => {
+        try {
+            const config = require(path.join(atom.project.getPaths()[0], configFileName))
+            if (config && config.resolve && config.resolve.modulesDirectories) {
+                moduleDirectory.push(...config.resolve.modulesDirectories)
+            }
+        } catch (e) {
+            /* do nothing */
+        }
+    })
+
     const options = {
         basedir,
+        moduleDirectory,
         extensions: atom.config.get('js-hyperclick.extensions')
     }
 

--- a/lib/suggestions.js
+++ b/lib/suggestions.js
@@ -13,13 +13,13 @@ function resolveModule(textEditor, module) {
     const moduleDirectory = [ 'node_modules' ]
     const webpackConfigs = atom.config.get('js-hyperclick.webpackConfigs')
     webpackConfigs.forEach(configFileName => {
+        let config;
         try {
-            const config = require(path.join(atom.project.getPaths()[0], configFileName))
-            if (config && config.resolve && config.resolve.modulesDirectories) {
-                moduleDirectory.push(...config.resolve.modulesDirectories)
-            }
+            config = require(path.join(atom.project.getPaths()[0], configFileName))
         } catch (e) {
-            /* do nothing */
+        }
+        if (config && config.resolve && config.resolve.modulesDirectories) {
+            moduleDirectory.push(...config.resolve.modulesDirectories)
         }
     })
 


### PR DESCRIPTION
Similar to https://github.com/AsaAyers/js-hyperclick/pull/9, but allows to specify modules directories relatively to the project.

It accepts array of paths to webpack configuration files, since there might be different config file names per project: `webpack.config.js`, `webpack.config.dev.js`, `webpack/dev.js` and so on.