### PR TITLE
feat: support folders && guess extension

### DIFF
--- a/lib/suggestions.js
+++ b/lib/suggestions.js
@@ -1,6 +1,7 @@
 "use babel"
 /*global atom */
 
+import fs from 'fs'
 import url from 'url'
 import shell from 'shell'
 import path from 'path'
@@ -26,8 +27,21 @@ function resolveModule(textEditor, module) {
 
     // Allow linking to relative files that don't exist yet.
     if (module[0] === '.') {
+        // if we have a module path without extension it might be
+        //   - a folder with `index.[ext]` file
+        //   - a file with any extension
         if (path.extname(module) == '') {
-            module += '.js'
+            // append `index` filename
+            let fullPath = path.join(basedir, module)
+            const isDir = fs.lstatSync(fullPath).isDirectory()
+            if (isDir) fullPath += '/index'
+
+            // find the best match
+            const foundFiles = fs.readdirSync(path.resolve(fullPath, '..'))
+            const fileNameWithoutExt = path.basename(fullPath)
+            const firstFileMatch = foundFiles.find(f => f.includes(fileNameWithoutExt))
+
+            module += `/${firstFileMatch}`
         }
 
         return path.join(basedir, module)


### PR DESCRIPTION
* Add support to require folder statements, will search for index.[ext] files
* Fix no extensions relative require statement resolve, try to guess the correct file without extension.