### PR TITLE
Make moduleDirectory customizable

### DIFF
--- a/lib/js-hyperclick.js
+++ b/lib/js-hyperclick.js
@@ -25,6 +25,12 @@ module.exports = {
             // Default comes from Node's `require.extensions`
             default: [ '.js', '.json', '.node' ],
             items: { type: 'string' },
+        },
+        moduleDirectories: {
+            description: "Comma separated list of directories to check for files",
+            type: 'array',
+            default: [ 'node_modules' ],
+            items: { type: 'string' },
         }
     },
     activate(state) {

--- a/lib/suggestions.js
+++ b/lib/suggestions.js
@@ -11,7 +11,8 @@ function resolveModule(textEditor, module) {
     const basedir = path.dirname(textEditor.getPath())
     const options = {
         basedir,
-        extensions: atom.config.get('js-hyperclick.extensions')
+        extensions: atom.config.get('js-hyperclick.extensions'),
+        moduleDirectory: atom.config.get('js-hyperclick.moduleDirectories')
     }
 
     try {


### PR DESCRIPTION
This feature allows users to customize the module directory setting when resolving files. This is useful for certain project stuctures e.g.

```
- /build
- /src
- package.json
- webpack.config.js
```

Inspired by [the comment](https://github.com/AsaAyers/js-hyperclick/issues/17#issuecomment-212885213) posted by @mctep