### PR TITLE
Added search paths option

### DIFF
--- a/lib/js-hyperclick.js
+++ b/lib/js-hyperclick.js
@@ -25,6 +25,12 @@ module.exports = {
             // Default comes from Node's `require.extensions`
             default: [ '.js', '.json', '.node' ],
             items: { type: 'string' },
+        },
+        searchPaths: {
+            description: "Comma separated list of paths in which to search for files",
+            type: 'array',
+            default: [ 'node_modules' ],
+            items: { type: 'string' },
         }
     },
     activate(state) {

--- a/lib/suggestions.js
+++ b/lib/suggestions.js
@@ -11,6 +11,7 @@ function resolveModule(textEditor, module) {
     const basedir = path.dirname(textEditor.getPath())
     const options = {
         basedir,
+        moduleDirectory: atom.config.get('js-hyperclick.searchPaths'),
         extensions: atom.config.get('js-hyperclick.extensions')
     }
 


### PR DESCRIPTION
Added a new option _Search Paths_ (base on the idea from [this article](https://medium.com/horrible-hacks/things-i-wish-i-knew-about-redux-9924abf2f9e0#.xdte90lw9) by @luqmaan). This way the plugin can be configured to work in projects were you use custom path resolution.