### PR TITLE
Add configuration option for custom module paths.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,32 @@ hope that it solves some of yours.
 
 # FAQ
 
+## I configured {babel,eslint,flow,webpack,etc} to avoid '../' in my imports. How can I configure `js-hyperclick`?
+
+First, I think it's a bad idea to do that and I never configure my projects this
+way. In a twitter conversation to see if we could standardize this across
+projects some good points were made:
+
+> @nodkz the module loader is locked (in node anyways) so any feature additions should be rejected
+>
+> -[@evanhlucas](https://twitter.com/evanhlucas/status/771750602967703561)
+
+and
+
+> @nodkz @left_pad @izs @slicknet @zpao I think this is at odds with Node resolution mechanism so it likely won’t happen.
+>
+> -[@dan_abramov](https://twitter.com/dan_abramov/status/771741318129324032)
+
+If you're still set on custom module directories, there is a way to configure
+it. If you keep your common modules in `src/lib` you can add this to your
+`package.json`:
+
+```json
+"moduleRoots": [ "src/lib" ],
+```
+
+With that in place `require('foo')` or `import 'foo'` with both locate your `src/lib/foo` module.
+
 ## Why doesn't `js-hyperclick` see my jsx files?
 
 There is a setting in `js-hyperclick` to add additional extensions. My
@@ -33,3 +59,4 @@ used RequireJS for years
 [hyperclick]: https://atom.io/packages/hyperclick
 [code-links]: https://atom.io/packages/code-links
 [resolve]: https://www.npmjs.com/package/resolvehttps://www.npmjs.com/package/resolve
+[webpack-config]: http://webpack.github.io/docs/configuration.html#resolve-modulesdirectories

--- a/lib/suggestions.js
+++ b/lib/suggestions.js
@@ -4,8 +4,69 @@
 import url from 'url'
 import shell from 'shell'
 import path from 'path'
+import fs from 'fs'
 import { sync as resolve } from 'resolve'
 import { Range } from 'atom'
+
+function findPackageJson(basedir) {
+    const packagePath = path.resolve(basedir, 'package.json')
+    try {
+        fs.accessSync(packagePath)
+    } catch (e) {
+        const parent = path.resolve(basedir, '../')
+        if (parent != basedir) {
+            return findPackageJson(parent)
+        }
+        return undefined
+    }
+    return packagePath
+}
+
+function loadModuleRoots(basedir) {
+    const packagePath = findPackageJson(basedir)
+    if (!packagePath) {
+        return
+    }
+    const config = JSON.parse(fs.readFileSync(packagePath))
+
+    if (config && config.moduleRoots) {
+        let roots = config.moduleRoots
+        if (typeof roots === 'string') {
+            roots = [ roots ]
+        }
+
+        const packageDir = path.dirname(packagePath)
+        return roots.map(
+            r => path.resolve(packageDir , r)
+        )
+    }
+}
+
+function resolveWithCustomRoots(basedir, absoluteModule) {
+    const module = `./${absoluteModule}`
+
+    const roots = loadModuleRoots(basedir)
+
+    if (roots) {
+        // Atom doesn't support custom roots, but I need something I can use
+        // to verify the feature works.
+        if (false) { require('make-cache') } // eslint-disable-line
+
+        const options = {
+            basedir,
+            extensions: atom.config.get('js-hyperclick.extensions'),
+        }
+        for (let i = 0; i < roots.length; i++) {
+            options.basedir = roots[i]
+
+            try {
+                return resolve(module, options)
+            } catch (e) {
+                /* do nothing */
+            }
+        }
+    }
+}
 
 function resolveModule(textEditor, module) {
     const basedir = path.dirname(textEditor.getPath())
@@ -31,6 +92,8 @@ function resolveModule(textEditor, module) {
         }
 
         return path.join(basedir, module)
+    } else {
+        return resolveWithCustomRoots(basedir, module)
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
       }
     }
   },
+  "moduleRoots": [
+      "lib"
+  ],
   "dependencies": {
     "acorn-to-esprima": "^1.0.4",
     "babel-core": "^5.8.25",


### PR DESCRIPTION
Even though I don't think it's a good idea to use this, I'm not going to
convince everyone and it's been requested by several people for over a year.

It was proposed we use [`moduleResolve`][tweet] as the key. I don't think it's
descriptive enough and is too similar to webpack's
[`modulesDirectories`][webpack] and [resolve's `moduleDirectory`][resolve].
Those options also don't really provide the correct behavior for this.

I chose `moduleRoots` because the behavior for this feature is most similar to
[webpack's `resolve.root`][webpack.root]. Webpack says you must use absolute
paths, but since our configuration is in JSON you must use paths relative to
`package.json`

Fixes #17
Fixes #27

[tweet]: https://twitter.com/nodkz/status/771735917203689472
[webpack]: http://webpack.github.io/docs/configuration.html#resolve-modulesdirectories
[resolve]: https://www.npmjs.com/package/resolve
[webpack.root]: http://webpack.github.io/docs/configuration.html#resolve-root