### PR TITLE
Add path navigation for exports

### DIFF
--- a/lib/make-cache.js
+++ b/lib/make-cache.js
@@ -126,6 +126,26 @@ export function parseCode(code) {
                 const { name, start, end } = declaration.id
                 exports[name] = { start, end }
             }
+
+            if (t.isLiteral(node.source)) {
+                const module = node.source.value
+                paths.push({
+                    start: node.source.start,
+                    end: node.source.end,
+                    module,
+                })
+            }
+
+        },
+        ExportAllDeclaration(node, parent) {
+            if (t.isLiteral(node.source)) {
+                const module = node.source.value
+                paths.push({
+                    start: node.source.start,
+                    end: node.source.end,
+                    module,
+                })
+            }
         },
         AssignmentExpression({left, start, end}, parent) {
             if (t.isMemberExpression(left)

--- a/spec/make-cache-spec.js
+++ b/spec/make-cache-spec.js
@@ -108,12 +108,20 @@ describe("makeCache.parseCode", function() {
         function whatever() {
             const x = require('something')
         }
+
+        export * from './export-all'
+        export { y } from './named-exports'
+        export default from './base/Component.react'
+
         `).paths
 
         expect(actual[0].module).toBe('./foo')
         expect(actual[1].module).toBe('./bar')
         expect(actual[2].module).toBe('./other')
         expect(actual[3].module).toBe('something')
+        expect(actual[4].module).toBe('./export-all')
+        expect(actual[5].module).toBe('./named-exports')
+        expect(actual[6].module).toBe('./base/Component.react')
     })
 
 


### PR DESCRIPTION
Enables path navigation for ExportNamedDeclaration and ExportAllDeclaration.

In the following example both `'./foo'` and `'./bar'` are navigable. 

```js
export * from './foo';
export { x, y } from './bar';
```