### PR TITLE
Use fs.realpathSync to avoid opening symlinks.

### DIFF
--- a/lib/js-hyperclick.js
+++ b/lib/js-hyperclick.js
@@ -9,6 +9,7 @@ import { Range as AtomRange } from 'atom'
 import shell from 'shell'
 import makeCache from './make-cache'
 import { buildSuggestion, findDestination, resolveModule } from './core'
+import fs from 'fs'
 
 
 const isJavascript = (textEditor: TextEditor) => {
@@ -97,10 +98,11 @@ function makeProvider(subscriptions) {
                 return
             }
 
+            const realFile = fs.realpathSync(filename)
             const options = {
                 pending: atom.config.get('js-hyperclick.usePendingPanes')
             }
-            atom.workspace.open(filename, options).then((editor) => {
+            atom.workspace.open(realFile, options).then((editor) => {
                 navigateToSuggestion(editor, suggestion)
             })
         } else {

--- a/spec/fixtures/es6-module.js
+++ b/spec/fixtures/es6-module.js
@@ -1,5 +1,10 @@
 /* eslint-disable */
 
+import symlink from './symlink'
+
+// Manual testing should show this opens all-imports.js instead of symlink.js
+console.log(symlink)
+
 var testVar /* testVar */
 let testLet /* testLet */
 const testConst /* testConst */ = null

--- a/spec/fixtures/symlink.js
+++ b/spec/fixtures/symlink.js
@@ -1,0 +1,1 @@
+all-imports.js


### PR DESCRIPTION
Originally proposed by @magicdawn

I couldn't think of any reason to ever open the symlink, so I decided to do it at the last moment before calling `atom.workspace.open(`.


Fixes #62 
Closes AsaAyers/js-hyperclick-core#4
Closes AsaAyers/js-hyperclick-core#5
