### PR TITLE
Add aliases for paths

### DIFF
--- a/lib/core/resolve-module.js
+++ b/lib/core/resolve-module.js
@@ -46,11 +46,11 @@ function loadModuleRoots(basedir) {
 function resolveWithCustomRoots(basedir, absoluteModule, options) {
   const { extensions = defaultExtensions } = options
   const moduleName = `./${absoluteModule}`
-
   const roots = loadModuleRoots(basedir)
 
   if (roots) {
     const resolveOptions = { basedir, extensions }
+
     for (let i = 0; i < roots.length; i++) {
       resolveOptions.basedir = roots[i]
 
@@ -63,6 +63,34 @@ function resolveWithCustomRoots(basedir, absoluteModule, options) {
   }
 }
 
+function loadModuleAliases(basedir) {
+  const packagePath = findPackageJson(basedir)
+  if (!packagePath) {
+    return
+  }
+  const config = JSON.parse(String(fs.readFileSync(packagePath)))
+
+  if (config && config.moduleAliases) {
+    return config.moduleAliases
+  }
+}
+
+function applyAliases (absoluteModule, aliases) {
+  const keys = Object.keys(aliases)
+  let i = keys.length
+
+  while (i--) {
+    const key = keys[i]
+    if (absoluteModule.indexOf(key) === 0) {
+      const regExp = new RegExp(`^${key}`)
+
+      return absoluteModule.replace(regExp, aliases[key])
+    }
+  }
+
+  return absoluteModule
+}
+
 export default function resolveModule(
   filePath: string,
   suggestion: { moduleName: string },
@@ -73,6 +101,13 @@ export default function resolveModule(
 
   const basedir = path.dirname(filePath)
   const resolveOptions = { basedir, extensions }
+  const alises = loadModuleAliases(basedir)
+
+  if (alises) {
+    console.log(moduleName)
+    moduleName = applyAliases(moduleName, alises)
+    console.log(moduleName)
+  }
 
   let filename
 

--- a/lib/core/resolve-module.js
+++ b/lib/core/resolve-module.js
@@ -104,9 +104,7 @@ export default function resolveModule(
   const alises = loadModuleAliases(basedir)
 
   if (alises) {
-    console.log(moduleName)
     moduleName = applyAliases(moduleName, alises)
-    console.log(moduleName)
   }
 
   let filename


### PR DESCRIPTION
Hi, it small request allow use alises for js-hyperclick.
For use alises necessary to add in package.json moduleAliases: { "alias": "replace path" }

I understand your posing why you are against aliases, but sometimes they can not be avoided.
I would be glad if you took my request.
