### PR TITLE
Resolves #81 Support for `atom` module

### DIFF
--- a/lib/core/resolve-module.js
+++ b/lib/core/resolve-module.js
@@ -85,7 +85,12 @@ export default function resolveModule(
       }
     }
   } catch (e) {
-    /* do nothing */
+    if (moduleName === "atom") {
+      return {
+        type: "url",
+        url: `https://atom.io/docs/api/latest/`,
+      }
+    }
   }
 
   // Allow linking to relative files that don't exist yet.


### PR DESCRIPTION
This is a lightweight solution for #81.

I didn't want to change much, so I opted to replace the `do nothing` comment in the `resolve` error catch with a check for the module name being `atom`. This way, it will only get to here if there is jo module called `atom` in a node_modules folder, or anywhere in the paths checked by `resolve` (there is [an unrelated package](https://www.npmjs.com/package/atom) called `atom` on npm, and I didn't want to disregard the possibility the user actually meant that one).

When the error occurs, and the module name is `atom`, it will return the same object as the `npm` one, except the URL is https://atom.io/docs/api/latest/. This autoresolves to the latest version, so future compatibility is not an issue. 

As I said in the issue, I would have preferred to go to the specific page for the class, but I don't think the class name was passed to the `resolveModule` function. As I didn't want to writeany parsing logic, I've left it with just going to the auto resolved page (which is currently https://atom.io/docs/api/v1.23.3/AtomEnvironment).

Specs all pass, but I'm not sure where or how to write any for this change.