### PR TITLE
Adding config for root path into Atom config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # js-hyperclick package
+### `supports setting up root path`
 
 A [hyperclick][hyperclick] provider that lets you jump to where variables are defined.
 
@@ -38,8 +39,8 @@ and
 > -[@dan_abramov](https://twitter.com/dan_abramov/status/771741318129324032)
 
 If you're still set on custom module directories, there is a way to configure
-it. If you keep your common modules in `src/lib` you can add this to your
-`package.json`:
+it. If you keep your common modules in `src/lib` you can add this through setting in 
+`js-hyperclick -> rootPath` or your `package.json`:
 
 ```json
 "moduleRoots": [ "src/lib" ],

--- a/lib/core/resolve-module.js
+++ b/lib/core/resolve-module.js
@@ -31,9 +31,10 @@ function loadModuleRoots(basedir) {
     return
   }
   const config = JSON.parse(String(fs.readFileSync(packagePath)))
-
-  if (config && config.moduleRoots) {
-    let roots = config.moduleRoots
+  const rootPath = atom.config.get("js-hyperclick.rootPath")
+  let roots = config.moduleRoots || rootPath
+  
+  if (roots) {
     if (typeof roots === "string") {
       roots = [roots]
     }

--- a/lib/js-hyperclick.js
+++ b/lib/js-hyperclick.js
@@ -183,6 +183,13 @@ module.exports = {
       default: [".js", ".json", ".node"],
       items: { type: "string" },
     },
+    rootPath: {
+      description:
+        "Adding rootPath for your modules",
+      type: "array",
+      default: [""],
+      items: { type: "string" },
+    },
     usePendingPanes: {
       type: "boolean",
       default: false,


### PR DESCRIPTION
Seems like there are good reasons both, to have modules in some path, or to not have them.
So I suppose it's good to have this setting, which users will be able to ignore and use default way,  or set-up, and use in a way without the relative path.
There is a bunch of legacy projects, that configured this way, and can't be changed.