### PR TITLE
Fixes #106 Use your project's Babel config if one is found

### DIFF
--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -2,7 +2,7 @@
 // @flow
 import parseCode from "./parse-code"
 import buildSuggestion from "./build-suggestion"
-import resolveModule, { hashFile } from "./resolve-module"
+import resolveModule from "./resolve-module"
 import findDestination from "./find-destination"
 
-export { parseCode, buildSuggestion, resolveModule, findDestination, hashFile }
+export { parseCode, buildSuggestion, resolveModule, findDestination }

--- a/lib/core/parse-code.js
+++ b/lib/core/parse-code.js
@@ -52,50 +52,52 @@ function findIdentifiers(node, identifiers = []) {
   throw new Error("Unknown node type")
 }
 
-export default function parseCode(code: string): Info {
+const makeDefaultConfig = () => ({
+  sourceType: "module",
+  // Enable as many plugins as I can so that people don't need to configure
+  // anything.
+  plugins: [
+    require("@babel/plugin-syntax-async-generators"),
+    require("@babel/plugin-syntax-bigint"),
+    require("@babel/plugin-syntax-class-properties"),
+    [
+      require("@babel/plugin-syntax-decorators"),
+      { decoratorsBeforeExport: false },
+    ],
+    require("@babel/plugin-syntax-do-expressions"),
+    require("@babel/plugin-syntax-dynamic-import"),
+    require("@babel/plugin-syntax-export-default-from"),
+    require("@babel/plugin-syntax-export-namespace-from"),
+    require("@babel/plugin-syntax-flow"),
+    require("@babel/plugin-syntax-function-bind"),
+    require("@babel/plugin-syntax-function-sent"),
+    require("@babel/plugin-syntax-import-meta"),
+    require("@babel/plugin-syntax-json-strings"),
+    require("@babel/plugin-syntax-jsx"),
+    require("@babel/plugin-syntax-logical-assignment-operators"),
+    require("@babel/plugin-syntax-nullish-coalescing-operator"),
+    require("@babel/plugin-syntax-numeric-separator"),
+    require("@babel/plugin-syntax-object-rest-spread"),
+    require("@babel/plugin-syntax-optional-catch-binding"),
+    require("@babel/plugin-syntax-optional-chaining"),
+    [
+      require("@babel/plugin-syntax-pipeline-operator"),
+      { proposal: "minimal" },
+    ],
+    require("@babel/plugin-syntax-throw-expressions"),
+    // Even though Babel can parse typescript, I can't have it and flow
+    // enabled at the same time.
+    // "@babel/plugin-syntax-typescript",
+  ],
+})
+
+export default function parseCode(code: string, babelConfig: ?Object): Info {
   const { traverse, types: t } = require("@babel/core")
-  const { parse } = require("@babel/core")
+  const { parseSync } = require("@babel/core")
   let ast = undefined
 
   try {
-    ast = parse(code, {
-      sourceType: "module",
-      // Enable as many plugins as I can so that people don't need to configure
-      // anything.
-      plugins: [
-        require("@babel/plugin-syntax-async-generators"),
-        require("@babel/plugin-syntax-bigint"),
-        require("@babel/plugin-syntax-class-properties"),
-        [
-          require("@babel/plugin-syntax-decorators"),
-          { decoratorsBeforeExport: false },
-        ],
-        require("@babel/plugin-syntax-do-expressions"),
-        require("@babel/plugin-syntax-dynamic-import"),
-        require("@babel/plugin-syntax-export-default-from"),
-        require("@babel/plugin-syntax-export-namespace-from"),
-        require("@babel/plugin-syntax-flow"),
-        require("@babel/plugin-syntax-function-bind"),
-        require("@babel/plugin-syntax-function-sent"),
-        require("@babel/plugin-syntax-import-meta"),
-        require("@babel/plugin-syntax-json-strings"),
-        require("@babel/plugin-syntax-jsx"),
-        require("@babel/plugin-syntax-logical-assignment-operators"),
-        require("@babel/plugin-syntax-nullish-coalescing-operator"),
-        require("@babel/plugin-syntax-numeric-separator"),
-        require("@babel/plugin-syntax-object-rest-spread"),
-        require("@babel/plugin-syntax-optional-catch-binding"),
-        require("@babel/plugin-syntax-optional-chaining"),
-        [
-          require("@babel/plugin-syntax-pipeline-operator"),
-          { proposal: "minimal" },
-        ],
-        require("@babel/plugin-syntax-throw-expressions"),
-        // Even though Babel can parse typescript, I can't have it and flow
-        // enabled at the same time.
-        // "@babel/plugin-syntax-typescript",
-      ],
-    })
+    ast = parseSync(code, babelConfig || makeDefaultConfig())
   } catch (parseError) {
     debug("parseError", parseError)
     /* istanbul ignore next */

--- a/lib/core/resolve-module.js
+++ b/lib/core/resolve-module.js
@@ -3,7 +3,6 @@
 import path from "path"
 import fs from "fs"
 import { sync as resolve } from "resolve"
-import crypto from "crypto"
 import type { Resolved } from "../types"
 import makeDebug from "debug"
 const debug = makeDebug("js-hyperclick:resolve-module")
@@ -12,10 +11,7 @@ const debug = makeDebug("js-hyperclick:resolve-module")
 const defaultExtensions = [".js", ".json", ".node"]
 type ResolveOptions = {
   extensions?: typeof defaultExtensions,
-  trustedResolvers: Array<{
-    hash: string,
-    trusted: boolean,
-  }>,
+  requireIfTrusted: (moduleName: string) => any,
 }
 
 function findPackageJson(basedir) {
@@ -50,23 +46,8 @@ function loadModuleRoots(basedir) {
   }
 }
 
-export const hashFile = (filename: string): string => {
-  const hash = crypto.createHash("sha1")
-  hash.setEncoding("hex")
-  hash.write(fs.readFileSync(filename))
-  hash.end()
-  return String(hash.read())
-}
-
-const resolverHashes = {
-  // [path.normalize( path.join(__dirname, '../../custom-resolver.js') )]: '0000000000000000000000000000000000000000',
-}
-
-const hasChanged = (filename, hash) =>
-  resolverHashes[filename] != null && resolverHashes[filename] != hash
-
 function resolveWithCustomRoots(basedir, absoluteModule, options): Resolved {
-  const { extensions = defaultExtensions } = options
+  const { extensions = defaultExtensions, requireIfTrusted } = options
   const moduleName = `./${absoluteModule}`
 
   const roots = loadModuleRoots(basedir)
@@ -84,33 +65,14 @@ function resolveWithCustomRoots(basedir, absoluteModule, options): Resolved {
 
       if (stats.isFile()) {
         const resolver = roots[i]
-        const hash = hashFile(resolver)
-        // Originally I was going to store the filename and a hash
-        // (trustedResolvers[resolver][hash] = true), but using a config key
-        // that contains a dot causes it to get broken up
-        // (trustedResolvers['custom-resolver']['js'][hash] = true)
-        const { trusted } =
-          options.trustedResolvers.find(tmp => tmp.hash === hash) || {}
-
-        if (trusted == null || hasChanged(resolver, hash)) {
-          return {
-            type: "resolver",
-            filename: resolver,
-            hash,
-            lastHash: resolverHashes[resolver],
-          }
-        } else if (trusted === false) {
-          continue
-        }
-
         try {
-          resolverHashes[resolver] = hash
           // $FlowExpectError
-          const customResolver = require(resolver)
+          const customResolver = requireIfTrusted(resolver)
           const filename = customResolver({
             basedir,
             moduleName: absoluteModule,
           })
+          debug("filename", filename)
           // it's ok for a custom resolver to jut pass on a module
           if (filename == null) {
             continue
@@ -149,7 +111,7 @@ function resolveWithCustomRoots(basedir, absoluteModule, options): Resolved {
 export default function resolveModule(
   filePath: string,
   suggestion: { moduleName: string },
-  options: ResolveOptions = { trustedResolvers: [] },
+  options: ResolveOptions,
 ): Resolved {
   const { extensions = defaultExtensions } = options
   let { moduleName } = suggestion

--- a/lib/js-hyperclick.js
+++ b/lib/js-hyperclick.js
@@ -2,7 +2,7 @@
 /*global atom */
 // @flow
 import type { TextEditor } from "atom"
-import type { Range } from "./types"
+import type { Range, Resolved } from "./types"
 import createDebug from "debug"
 
 import { CompositeDisposable } from "atom"
@@ -11,6 +11,8 @@ import shell from "shell"
 import makeCache from "./make-cache"
 import { buildSuggestion, findDestination, resolveModule } from "./core"
 import fs from "fs"
+import makeRequire from "./require-if-trusted"
+import type { Require } from "./require-if-trusted"
 
 const debug = createDebug("js-hyperclick")
 
@@ -87,61 +89,28 @@ function makeProvider(subscriptions) {
     }
   }
 
-  function updateTrustedResolvers(hash, value) {
-    const key = `js-hyperclick.trustedResolvers`
-    const trustedResolvers = atom.config.get(key) || []
-    debug("Updating trusted resolver", hash, value)
-    atom.config.set(key, [...trustedResolvers, { hash, trusted: value }])
-  }
-
   const followSuggestionPath = (fromFile, suggestion) => {
+    let blockNotFoundWarning = false
+    const requireIfTrusted: Require<() => ?Resolved> = makeRequire(
+      isTrusted => {
+        if (isTrusted) {
+          followSuggestionPath(fromFile, suggestion)
+        }
+
+        blockNotFoundWarning = true
+        return () => undefined
+      },
+    )
     const resolveOptions = {
       extensions: atom.config.get("js-hyperclick.extensions"),
-      trustedResolvers: atom.config.get("js-hyperclick.trustedResolvers") || [],
+      requireIfTrusted,
     }
     debug("resolveOptions", resolveOptions)
-    let resolved = resolveModule(fromFile, suggestion, resolveOptions)
+    const resolved = resolveModule(fromFile, suggestion, resolveOptions)
 
-    if (resolved.type === "resolver") {
-      const { filename, hash, lastHash } = resolved
-      const message = "js-hyperclick: Trust this custom resolver?"
-      let detail = `filename: ${filename}\nhash: ${resolved.hash}`
-
-      if (lastHash) {
-        detail += `\nprevious hash: ${lastHash}`
-        detail += `\nThe file has changed and atom must reload to use it.`
-      }
-
-      const notification = atom.notifications.addInfo(message, {
-        detail,
-        dismissable: true,
-        buttons: [
-          {
-            text: lastHash ? "Trust & Restart" : "Trust",
-            onDidClick() {
-              updateTrustedResolvers(hash, true)
-              notification.dismiss()
-
-              if (lastHash) {
-                return atom.reload()
-              }
-
-              followSuggestionPath(fromFile, suggestion)
-            },
-          },
-          {
-            text: "Never",
-            onDidClick() {
-              updateTrustedResolvers(hash, false)
-              notification.dismiss()
-            },
-          },
-        ],
-      })
-      resolved = { type: "file", filename }
-    }
-
-    if (resolved.type === "url") {
+    if (blockNotFoundWarning) {
+      // Do nothing
+    } else if (resolved.type === "url") {
       if (atom.packages.isPackageLoaded("web-browser")) {
         atom.workspace.open(resolved.url)
       } else {
@@ -232,6 +201,15 @@ function makeProvider(subscriptions) {
   }
 }
 
+function migrateTrustedResolvers() {
+  const key = `js-hyperclick.trustedResolvers`
+  const trustedResolvers = atom.config.get(key)
+  if (trustedResolvers != null) {
+    atom.config.set("js-hyperclick.trustedFiles", trustedResolvers)
+    atom.config.set(key, undefined)
+  }
+}
+
 module.exports = {
   config: {
     extensions: {
@@ -267,23 +245,24 @@ module.exports = {
     },
     // This doesn't show up in the settings. Use Edit > Config if you need to
     // change this.
-    trustedResolvers: {
-      type: "array",
-      items: {
-        type: "object",
-        properties: {
-          hash: { type: "string" },
-          trusted: { type: "boolean" },
-        },
-      },
-      default: [],
-    },
+    // trustedFiles: {
+    //   type: "array",
+    //   items: {
+    //     type: "object",
+    //     properties: {
+    //       hash: { type: "string" },
+    //       trusted: { type: "boolean" },
+    //     },
+    //   },
+    //   default: [],
+    // },
   },
   activate() {
     // hyperclick is bundled into nuclide
     if (!atom.packages.isPackageLoaded("hyperclick")) {
       require("atom-package-deps").install("js-hyperclick")
     }
+    migrateTrustedResolvers()
     debug("activate")
     this.subscriptions = new CompositeDisposable()
   },

--- a/lib/make-cache.js
+++ b/lib/make-cache.js
@@ -1,13 +1,104 @@
 "use babel"
 // @flow
 
+import path from "path"
+import fs from "fs"
 import type { CompositeDisposable, TextEditor } from "atom"
 import type { Info } from "./types"
 import { parseCode } from "./core"
+import makeDebug from "debug"
+import makeRequire from "./require-if-trusted"
+
+const debug = makeDebug("js-hyperclick:make-cache")
+
+function findFile(basedir, filenames) {
+  for (let i = 0; i < filenames.length; i++) {
+    try {
+      const absolutePath = path.resolve(basedir, filenames[i])
+      fs.accessSync(absolutePath)
+      return absolutePath
+    } catch (e) {
+      // Skip this file, it probably doesn't exist
+    }
+  }
+
+  const parent = path.resolve(basedir, "../")
+  if (parent != basedir) {
+    return findFile(parent, filenames)
+  }
+  return undefined
+}
 
 export default function cachedParser(subscriptions: CompositeDisposable) {
   const editors = new WeakMap()
   const data: WeakMap<TextEditor, Info> = new WeakMap()
+  const configCache: WeakMap<TextEditor, ?Object> = new WeakMap()
+
+  function findConfigFile(editor: TextEditor) {
+    const basedir = path.dirname(editor.getPath())
+    // "New in Babel 7.x, Babel has as concept of a "root" directory, which
+    // defaults to the current working directory"
+    // https://babeljs.io/docs/en/config-files#project-wide-configuration
+    //
+    // The current working directory doesn't work well for `js-hyperclick`
+    // because you might launch Atom from anywhere and you can add multiple
+    // projects at once.
+    let configPath = findFile(basedir, ["babel.config.js"])
+    if (configPath == null) {
+      configPath = findFile(basedir, [".babelrc", ".babelrc.js"])
+    }
+
+    return configPath
+  }
+
+  function loadBabelConfig(editor) {
+    if (!configCache.has(editor)) {
+      let babelConfig: ?Object = undefined
+      const configPath = findConfigFile(editor)
+      if (configPath != null) {
+        debug("loadBabelConfig", configPath)
+        try {
+          if (path.extname(configPath) === ".js") {
+            const dontCache = {}
+
+            const requireIfTrusted = makeRequire(trusted => {
+              if (trusted === false) {
+                return undefined
+              }
+              if (trusted === true) {
+                data.delete(editor)
+                configCache.delete(editor)
+              }
+
+              return dontCache
+            })
+
+            // $FlowExpectError
+            const cfg = requireIfTrusted(configPath)
+            debug("cfg", cfg)
+
+            babelConfig = typeof cfg === "function" ? cfg() : cfg
+            if (babelConfig === dontCache) {
+              return undefined
+            }
+          } else {
+            babelConfig = JSON.parse(String(fs.readFileSync(configPath)))
+          }
+
+          if (babelConfig) {
+            babelConfig.cwd = babelConfig.cwd || path.dirname(configPath)
+            const babel = require("@babel/core")
+            babelConfig = babel.loadOptions(babelConfig)
+          }
+        } catch (e) {
+          debug("loadBabelConfig error", e)
+        }
+        debug("babel config", babelConfig)
+      }
+      configCache.set(editor, babelConfig)
+    }
+    return configCache.get(editor)
+  }
 
   function watchEditor(editor) {
     if (!editors.has(editor)) {
@@ -24,7 +115,7 @@ export default function cachedParser(subscriptions: CompositeDisposable) {
     get(editor: TextEditor): Info {
       watchEditor(editor)
       if (!data.has(editor)) {
-        data.set(editor, parseCode(editor.getText()))
+        data.set(editor, parseCode(editor.getText(), loadBabelConfig(editor)))
       }
 
       // $FlowExpectError - Flow thinks it might return null here

--- a/lib/require-if-trusted.js
+++ b/lib/require-if-trusted.js
@@ -1,0 +1,106 @@
+// @flow
+import fs from "fs"
+import crypto from "crypto"
+import makeDebug from "debug"
+const debug = makeDebug("js-hyperclick:require-if-trusted")
+
+const hashFile = (filename: string): string => {
+  const hash = crypto.createHash("sha1")
+  hash.setEncoding("hex")
+  hash.write(fs.readFileSync(filename))
+  hash.end()
+  return String(hash.read())
+}
+
+const fileHashes = {}
+
+const hasChanged = (filename, hash) =>
+  fileHashes[filename] != null && fileHashes[filename] != hash
+
+export type Fallback<T> = (trusted: boolean) => T
+
+export type Require<T> = (moduleName: string) => T
+
+const configKey = "js-hyperclick.trustedFiles"
+function updateTrust(hash, trusted) {
+  const trustedFiles = (atom.config.get(configKey) || []).filter(
+    tmp => tmp.hash !== hash,
+  )
+
+  const newConfig = [...trustedFiles, { hash, trusted }]
+  debug("updateTrust", newConfig)
+
+  atom.config.set(configKey, newConfig)
+}
+
+function promptUser({ path, hash, lastHash, fallback }) {
+  const message = "js-hyperclick: Trust and execute this file?"
+  let detail = `filename: ${path}\nhash: ${hash}`
+
+  if (lastHash) {
+    detail += `\nprevious hash: ${lastHash}`
+    detail += `\nThe file has changed and atom must reload to use it.`
+  }
+
+  debug("promptUser", path)
+  const options = {
+    pending: atom.config.get("js-hyperclick.usePendingPanes"),
+  }
+  const untrustedFile = atom.workspace.open(path, options)
+  const notification = atom.notifications.addInfo(message, {
+    detail,
+    dismissable: true,
+    buttons: [
+      {
+        text: lastHash ? "Trust & Restart" : "Trust",
+        onDidClick() {
+          updateTrust(hash, true)
+          notification.dismiss()
+
+          if (lastHash) {
+            return atom.reload()
+          }
+          debug("Trust")
+          fallback(true)
+          untrustedFile.then(editor => {
+            editor.destroy()
+          })
+        },
+      },
+      {
+        text: "Never",
+        onDidClick() {
+          updateTrust(hash, false)
+          notification.dismiss()
+        },
+      },
+    ],
+  })
+}
+
+export default function makeRequire<T>(fallback: Fallback<T>): Require<T> {
+  return function requireIfTrusted(path: string): T {
+    const trustedFiles = atom.config.get(configKey) || []
+
+    const hash = hashFile(path)
+    // Originally I was going to store the filename and a hash
+    // (trustedFiles[path][hash] = true), but using a config key
+    // that contains a dot causes it to get broken up
+    // (trustedFiles['some-path']['js'][hash] = true)
+    const { trusted } = trustedFiles.find(tmp => tmp.hash === hash) || {}
+
+    const changed = hasChanged(path, hash)
+    const lastHash = fileHashes[path]
+
+    if (trusted && !changed) {
+      fileHashes[path] = hash
+      // $FlowExpectError
+      return require(path)
+    }
+
+    if (trusted == null || changed) {
+      promptUser({ path, hash, lastHash, fallback })
+    }
+    return fallback(false)
+  }
+}

--- a/lib/types.js
+++ b/lib/types.js
@@ -8,7 +8,6 @@ export type Range = {|
 export type Resolved =
   | {| type: "url", url: string |}
   | {| type: "file", filename: ?string |}
-  | {| type: "resolver", filename: string, hash: string, lastHash: ?string |}
 
 type ExternalModule = {|
   local: string,

--- a/spec/find-destination-spec.js
+++ b/spec/find-destination-spec.js
@@ -24,6 +24,9 @@ const buildExpectations = srcFilename =>
         return buildSuggestion(info, text, { start, end })
       }
     }
+    const options = {
+      requireIfTrusted: require,
+    }
     spec.addMatchers({
       toLinkToExternalModuleLocation(endAnnotation) {
         const startAnnotation = this.actual
@@ -32,7 +35,7 @@ const buildExpectations = srcFilename =>
         let actual
         let destinationAnnotations = {}
         if (suggestion != null && suggestion.type === "from-import") {
-          const resolved = resolveModule(srcFilename, suggestion)
+          const resolved = resolveModule(srcFilename, suggestion, options)
 
           if (typeof resolved.filename !== "undefined") {
             const tmp = extractAnnotations(resolved.filename)


### PR DESCRIPTION
If your Babel config is a JavaScript file `js-hyperclick` will show it and ask if you trust it before executing it. If the config is a `.babelrc`, it is just read and used.